### PR TITLE
修复: 移除 onDidAccept 中多余的 quickPick.dispose() 调用

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,8 +289,6 @@ export function activate(context: vscode.ExtensionContext) {
 					vscode.commands.executeCommand('issueManager.refreshAllViews');
 				}, 1000);
 			}
-			
-			quickPick.dispose();
 		});
 
 		// 监听 QuickPick 隐藏事件，确保资源清理


### PR DESCRIPTION
- 确保资源清理完全依赖 onDidHide 事件处理器
- 避免重复调用 dispose() 方法
- 提升代码的健壮性和一致性