### PR TITLE
feat: 在关注问题视图菜单栏中新增打开问题目录按钮

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
       {
         "command": "issueManager.moveTo",
         "title": "移动到..."
+      },
+      {
+        "command": "issueManager.openIssueDir",
+        "title": "在 VS Code 中打开问题目录",
+        "icon": "$(home)"
       }
     ],
     "submenus": [
@@ -170,9 +175,19 @@
           "group": "navigation@1"
         },
         {
-          "command": "issueManager.searchIssuesInFocused",
+          "command": "issueManager.openIssueDir",
           "when": "view == issueManager.views.focused",
           "group": "navigation@1"
+        },
+        {
+          "command": "issueManager.searchIssuesInFocused",
+          "when": "view == issueManager.views.focused",
+          "group": "navigation@2"
+        },
+        {
+          "command": "issueManager.createIssueFromFocused",
+          "when": "view == issueManager.views.focused",
+          "group": "navigation@3"
         },
         {
           "command": "issueManager.createIssue",
@@ -185,13 +200,9 @@
           "group": "navigation@1"
         },
         {
-          "command": "issueManager.createIssueFromFocused",
-          "when": "view == issueManager.views.focused"
-        },
-        {
           "command": "issueManager.refreshAllViews",
           "when": "view == issueManager.views.recent || view == issueManager.views.focused",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "issueManager.setRecentIssuesViewMode.group",

--- a/src/commands/openIssueDir.ts
+++ b/src/commands/openIssueDir.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import { getIssueDir } from '../config';
+
+/**
+ * 打开问题目录命令
+ * 在 VS Code 中打开配置的问题目录
+ */
+export function registerOpenIssueDirCommand(context: vscode.ExtensionContext) {
+    const disposable = vscode.commands.registerCommand('issueManager.openIssueDir', () => {
+        const issueDir = getIssueDir();
+        if (!issueDir) {
+            vscode.window.showWarningMessage('问题目录未配置，请先在设置中配置 issueManager.issueDir');
+            return;
+        }
+
+        try {
+            // 使用 vscode.Uri.file 创建文件 URI
+            const issueDirUri = vscode.Uri.file(issueDir);
+            // 在 VS Code 中打开文件夹
+            vscode.commands.executeCommand('vscode.openFolder', issueDirUri, { forceNewWindow: false });
+        } catch (error) {
+            vscode.window.showErrorMessage(`打开问题目录失败: ${error}`);
+        }
+
+    });
+    context.subscriptions.push(disposable);
+};

--- a/src/commands/openIssueDir.ts
+++ b/src/commands/openIssueDir.ts
@@ -6,7 +6,7 @@ import { getIssueDir } from '../config';
  * 在 VS Code 中打开配置的问题目录
  */
 export function registerOpenIssueDirCommand(context: vscode.ExtensionContext) {
-    const disposable = vscode.commands.registerCommand('issueManager.openIssueDir', () => {
+    const disposable = vscode.commands.registerCommand('issueManager.openIssueDir', async () => {
         const issueDir = getIssueDir();
         if (!issueDir) {
             vscode.window.showWarningMessage('问题目录未配置，请先在设置中配置 issueManager.issueDir');
@@ -17,11 +17,11 @@ export function registerOpenIssueDirCommand(context: vscode.ExtensionContext) {
             // 使用 vscode.Uri.file 创建文件 URI
             const issueDirUri = vscode.Uri.file(issueDir);
             // 在 VS Code 中打开文件夹
-            vscode.commands.executeCommand('vscode.openFolder', issueDirUri, { forceNewWindow: false });
-        } catch (error) {
-            vscode.window.showErrorMessage(`打开问题目录失败: ${error}`);
+            await vscode.commands.executeCommand('vscode.openFolder', issueDirUri, { forceNewWindow: false });
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            vscode.window.showErrorMessage(`打开问题目录失败: ${message}`);
         }
-
     });
     context.subscriptions.push(disposable);
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import { moveToCommand } from './commands/moveTo';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getIssueDir } from './config';
+import { registerOpenIssueDirCommand } from './commands/openIssueDir';
 import { IssueOverviewProvider } from './views/IssueOverviewProvider';
 import { registerSearchIssuesCommand } from './commands/searchIssues';
 import { FocusedIssuesProvider } from './views/FocusedIssuesProvider';
@@ -50,6 +51,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// 注册“问题总览视图搜索”命令
 	registerSearchIssuesCommand(context);
+
+	registerOpenIssueDirCommand(context);
 	// 注册“孤立问题”视图
 	const isolatedIssuesProvider = new IsolatedIssuesProvider(context);
 	// vscode.window.registerTreeDataProvider('issueManager.views.isolated', isolatedIssuesProvider);


### PR DESCRIPTION
- 在 package.json 中新增 issueManager.openIssueDir 命令配置
- 在关注问题视图标题栏添加打开问题目录按钮
- 新增 src/commands/openIssueDir.ts 实现打开问题目录功能
- 使用 home 图标，点击可在 VS Code 中打开配置的问题目录
- 包含错误处理，当问题目录未配置时显示友好提示