### PR TITLE
feat(command): 新增 openAndRevealIssue 命令以在视图中定位文件

### DIFF
--- a/src/core/CommandRegistry.ts
+++ b/src/core/CommandRegistry.ts
@@ -100,7 +100,26 @@ export class CommandRegistry extends BaseCommandRegistry {
             // 5. 注册问题操作和创建命令
             this.registerIssueOperationCommands();
 
-            // 6. 注册结构视图命令
+            // 6. 注册“打开并定位”命令
+            this.context.subscriptions.push(
+                vscode.commands.registerCommand('issueManager.openAndRevealIssue', async (node: IssueTreeNode, type: 'focused' | 'overview') => {
+                    if (!node || !node.resourceUri) { return; }
+                    // 打开文件
+                    await vscode.window.showTextDocument(node.resourceUri, { preview: false });
+                    if (type === 'overview') {
+                        await vscode.commands.executeCommand('issueManager.views.overview.reveal', node, { select: true, focus: true, expand: true });
+                    } else if (type === 'focused') {
+                        const { node: target } = focusedIssuesProvider.findFirstFocusedNodeById(node.id) || {};
+                        if (target) {
+                            await vscode.commands.executeCommand('issueManager.views.focused.reveal', target, { select: true, focus: true, expand: true });
+                        } else {
+                            await vscode.commands.executeCommand('issueManager.views.overview.reveal', node, { select: true, focus: true, expand: true });
+                        }
+                    }
+                })
+            );
+
+            // 7. 注册结构视图命令
             this.registerStructureViewCommands(issueStructureProvider);
             
             this.logger.info('✅ 所有命令注册完成');

--- a/src/core/CommandRegistry.ts
+++ b/src/core/CommandRegistry.ts
@@ -106,14 +106,16 @@ export class CommandRegistry extends BaseCommandRegistry {
                     if (!node || !node.resourceUri) { return; }
                     // 打开文件
                     await vscode.window.showTextDocument(node.resourceUri, { preview: false });
+                    const revealInOverview = () => vscode.commands.executeCommand('issueManager.views.overview.reveal', node, { select: true, focus: true, expand: true });  
+
                     if (type === 'overview') {
-                        await vscode.commands.executeCommand('issueManager.views.overview.reveal', node, { select: true, focus: true, expand: true });
+                        await revealInOverview();
                     } else if (type === 'focused') {
                         const { node: target } = focusedIssuesProvider.findFirstFocusedNodeById(node.id) || {};
                         if (target) {
                             await vscode.commands.executeCommand('issueManager.views.focused.reveal', target, { select: true, focus: true, expand: true });
                         } else {
-                            await vscode.commands.executeCommand('issueManager.views.overview.reveal', node, { select: true, focus: true, expand: true });
+                            await revealInOverview();
                         }
                     }
                 })

--- a/src/core/commands/ViewCommandRegistry.ts
+++ b/src/core/commands/ViewCommandRegistry.ts
@@ -13,6 +13,7 @@ export class ViewCommandRegistry extends BaseCommandRegistry {
     private focusedIssuesProvider?: IFocusedIssuesProvider;
     private issueOverviewProvider?: IIssueOverviewProvider;
     private recentIssuesProvider?: IIssueViewProvider;
+    private overviewView?: vscode.TreeView<IssueTreeNode>;
     private focusedView?: vscode.TreeView<IssueTreeNode>;
 
     /**
@@ -30,7 +31,7 @@ export class ViewCommandRegistry extends BaseCommandRegistry {
         this.focusedIssuesProvider = providers.focusedIssuesProvider;
         this.issueOverviewProvider = providers.issueOverviewProvider;
         this.recentIssuesProvider = providers.recentIssuesProvider;
-        // overviewView is passed in but not stored as it's not needed for command registration
+        this.overviewView = providers.overviewView;
         this.focusedView = providers.focusedView;
     }
 
@@ -43,6 +44,7 @@ export class ViewCommandRegistry extends BaseCommandRegistry {
         this.registerViewRefreshCommands();
         this.registerViewNavigationCommands();
         this.registerViewToggleCommands();
+        this.registerViewRevealCommands();
     }
 
     /**
@@ -159,5 +161,24 @@ export class ViewCommandRegistry extends BaseCommandRegistry {
             },
             '切换视图焦点'
         );
+    }
+
+    /**
+     * 注册视图定位相关命令
+     */
+    private registerViewRevealCommands(): void {
+        this.registerCommand('issueManager.views.overview.reveal', async (...args: unknown[]) => {
+            const [node, options] = args as [IssueTreeNode, { select: boolean, focus: boolean, expand: boolean } | undefined];
+            if (this.overviewView && node) {
+                await this.overviewView.reveal(node, options);
+            }
+        }, '在总览视图中定位');
+
+        this.registerCommand('issueManager.views.focused.reveal', async (...args: unknown[]) => {
+            const [node, options] = args as [IssueTreeNode, { select: boolean, focus: boolean, expand: boolean } | undefined];
+            if (this.focusedView && node) {
+                await this.focusedView.reveal(node, options);
+            }
+        }, '在关注视图中定位');
     }
 }


### PR DESCRIPTION
- 新增 `issueManager.openAndRevealIssue` 命令，用于在打开问题的同时，在对应的树状视图（总览或关注）中高亮并定位该问题。
- 为支持此功能，在 `ViewCommandRegistry` 中注册了两个新的内部命令：
  - `issueManager.views.overview.reveal`
  - `issueManager.views.focused.reveal`
- 重构了 `ViewCommandRegistry` 以存储 `overviewView` 和 `focusedView` 的实例，使其能够调用 `reveal` API。
- 更新了 `CommandRegistry` 以协调这些命令的调用逻辑，在打开文件后执行相应的定位操作。